### PR TITLE
Github action cross compile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,12 @@
 name: publish
 
-# on:
-#   push:
-#     push:
-#       branches: "master"
-#     tags:
-#       - "*"
-
 on:
-  # pull_request:
   push:
-    branches:
-      - main
-    # tags:
-    #   - '*'
+    push:
+      branches: main
+    tags:
+      - "*"
+
 
 jobs:
   deploy-linux:


### PR DESCRIPTION
Hi little brother, 
I made this pull request to trigger a GitHub action at each tag and compile `rmt.rs` for macOS and Linux on many architectures. 
I recommend you review the GitHub action during the merge of squash my commits because I made many to test the GitHub action directly.

The output artefact:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/24889239/193369455-a6cb2340-a175-4a8d-9327-ad600d82eb47.png">


